### PR TITLE
XIVY-3123 Use correct maven profile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
         script {
           def workspace = pwd()
           def phase = env.BRANCH_NAME == 'master' ? 'deploy' : 'verify'
-          maven cmd: "-P repo.axonivy.com clean ${phase} -Dmaven.test.failure.ignore=true  " + 
+          maven cmd: "-P deploy.repo.axonivy.com clean ${phase} -Dmaven.test.failure.ignore=true  " + 
                      "-Dengine.directory=${workspace}/HtmlDialogDemos/HtmlDialogDemos/target/ivyEngine " +
                      "-Divy.engine.list.url=${params.engineListUrl} "
         }


### PR DESCRIPTION
I updated the parent declaration in [pom](https://github.com/ivy-samples/ivy-project-demos/blob/master/DemosApp/pom.xml) which pointed on an old artifact that we renamed/removed (ch.ivyteam.ivy.build.config.dependencies).

Failing build: https://jenkins.ivyteam.io/job/ivy-project-demos/job/master/35/
Build with updated profile: https://jenkins.ivyteam.io/job/ivy-project-demos/job/master/36/