### PR TITLE
Downgrade version from 9.1.0-SNAP to 8.0.1-SNAP

### DIFF
--- a/ConnectivityDemos/ConnectivityDemos/pom.xml
+++ b/ConnectivityDemos/ConnectivityDemos/pom.xml
@@ -5,13 +5,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project.demo</groupId>
 	<artifactId>connectivity-demos</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>iar</packaging>
 
 	<parent>
 		<groupId>ch.ivyteam.ivy.project</groupId>
 		<artifactId>build.maven.iar</artifactId>
-		<version>9.1.0-SNAPSHOT</version>
+		<version>8.0.1-SNAPSHOT</version>
 		<relativePath>../../build.maven/iar</relativePath>
 	</parent>
 	

--- a/ConnectivityDemos/ConnectivityDemosRCPTest/pom.xml
+++ b/ConnectivityDemos/ConnectivityDemosRCPTest/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>ch.ivyteam.ivy</groupId>
 		<artifactId>ch.ivyteam.ivy.build.config.test.rcptt</artifactId>
-		<version>9.1.0-SNAPSHOT</version>
+		<version>8.0.1-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/ConnectivityDemos/ConnectivityDemosTest/pom.xml
+++ b/ConnectivityDemos/ConnectivityDemosTest/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>ch.ivyteam.ivy.project</groupId>
 		<artifactId>build.maven.iar.web.test</artifactId>
-		<version>9.1.0-SNAPSHOT</version>
+		<version>8.0.1-SNAPSHOT</version>
 		<relativePath>../../build.maven/iar/web.test</relativePath>
 	</parent>
 
 	<groupId>ch.ivyteam.ivy.project.demo</groupId>
 	<artifactId>connectivity-demos-test</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>iar</packaging>
 
 	<properties>

--- a/ConnectivityDemos/pom.xml
+++ b/ConnectivityDemos/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project.demo</groupId>
 	<artifactId>connectivity-demos-modules</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/ErrorHandlingDemos/pom.xml
+++ b/ErrorHandlingDemos/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>ch.ivyteam.ivy.project</groupId>
     <artifactId>build.maven.iar</artifactId>
-    <version>9.1.0-SNAPSHOT</version>
+    <version>8.0.1-SNAPSHOT</version>
     <relativePath>../build.maven/iar</relativePath>
   </parent>
   <groupId>ch.ivyteam.ivy.project.demo</groupId>
   <artifactId>error-handling-demos</artifactId>
-  <version>9.1.0-SNAPSHOT</version>
+  <version>8.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
 
   <build>

--- a/HtmlDialogDemos/HtmlDialogDemos/pom.xml
+++ b/HtmlDialogDemos/HtmlDialogDemos/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project.demo</groupId>
 	<artifactId>html-dialog-demos</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>iar</packaging>
 	<description>Demo Project for the Html Dialog Features</description>
 	<organization>
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>ch.ivyteam.ivy.project</groupId>
 		<artifactId>build.maven.iar</artifactId>
-		<version>9.1.0-SNAPSHOT</version>
+		<version>8.0.1-SNAPSHOT</version>
 		<relativePath>../../build.maven/iar</relativePath>
 	</parent>
 </project>

--- a/HtmlDialogDemos/HtmlDialogDemosTest/pom.xml
+++ b/HtmlDialogDemos/HtmlDialogDemosTest/pom.xml
@@ -5,12 +5,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project.demo</groupId>
 	<artifactId>html-dialog-demos-test</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>iar</packaging>
 	<parent>
 		<groupId>ch.ivyteam.ivy.project</groupId>
 		<artifactId>build.maven.iar.web.test</artifactId>
-		<version>9.1.0-SNAPSHOT</version>
+		<version>8.0.1-SNAPSHOT</version>
 		<relativePath>../../build.maven/iar/web.test</relativePath>
 	</parent>
 

--- a/HtmlDialogDemos/pom.xml
+++ b/HtmlDialogDemos/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project</groupId>
 	<artifactId>html-dialog-demos-modules</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/QuickStartTutorial/pom.xml
+++ b/QuickStartTutorial/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ch.ivyteam.ivy.project.demo</groupId>
   <artifactId>quick-start-tutorial</artifactId>
-  <version>9.1.0-SNAPSHOT</version>
+  <version>8.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
   <build>
     <plugins>
@@ -18,7 +18,7 @@
   <parent>
   	<groupId>ch.ivyteam.ivy.project</groupId>
   	<artifactId>build.maven.iar</artifactId>
-  	<version>9.1.0-SNAPSHOT</version>
+  	<version>8.0.1-SNAPSHOT</version>
   	<relativePath>../build.maven/iar</relativePath>
   </parent>
 </project>

--- a/WorkflowDemos/WorkflowDemos/pom.xml
+++ b/WorkflowDemos/WorkflowDemos/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>ch.ivyteam.ivy.project</groupId>
     <artifactId>build.maven.iar</artifactId>
-    <version>9.1.0-SNAPSHOT</version>
+    <version>8.0.1-SNAPSHOT</version>
     <relativePath>../../build.maven/iar</relativePath>
   </parent>
   <groupId>ch.ivyteam.ivy.project.demo</groupId>
   <artifactId>workflow-demos</artifactId>
-  <version>9.1.0-SNAPSHOT</version>
+  <version>8.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
   <build>
     <plugins>

--- a/WorkflowDemos/WorkflowDemosTest/pom.xml
+++ b/WorkflowDemos/WorkflowDemosTest/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>ch.ivyteam.ivy.project</groupId>
 		<artifactId>build.maven.iar.web.test</artifactId>
-		<version>9.1.0-SNAPSHOT</version>
+		<version>8.0.1-SNAPSHOT</version>
 		<relativePath>../../build.maven/iar/web.test</relativePath>
 	</parent>
 
 	<groupId>ch.ivyteam.ivy.project.demo</groupId>
 	<artifactId>workflow-demos-test</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>iar</packaging>
 
 	<dependencies>

--- a/WorkflowDemos/pom.xml
+++ b/WorkflowDemos/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project</groupId>
 	<artifactId>workflowdemos.modules</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/build.maven/iar/pom.xml
+++ b/build.maven/iar/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>ch.ivyteam.ivy.project</groupId>
 		<artifactId>build.maven</artifactId>
-		<version>9.1.0-SNAPSHOT</version>
+		<version>8.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/build.maven/iar/web.test/pom.xml
+++ b/build.maven/iar/web.test/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>ch.ivyteam.ivy.project</groupId>
 		<artifactId>build.maven.iar</artifactId>
-		<version>9.1.0-SNAPSHOT</version>
+		<version>8.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/build.maven/job/update-version/pom.xml
+++ b/build.maven/job/update-version/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy</groupId>
 	<artifactId>update-ivy-projects-version</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<description>Adjusts the version of the ivyProjects.</description>

--- a/build.maven/pom.xml
+++ b/build.maven/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project</groupId>
 	<artifactId>build.maven</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<organization>

--- a/build.maven/rcptt/pom.xml
+++ b/build.maven/rcptt/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 		<groupId>ch.ivyteam.ivy.project</groupId>
 	<artifactId>ch.ivyteam.ivy.build.config.test.rcptt</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.ivyteam.ivy.project</groupId>
 	<artifactId>ivyProject.modules</artifactId>
-	<version>9.1.0-SNAPSHOT</version>
+	<version>8.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<description>Contains all ivyProjects as module dependency</description>
 


### PR DESCRIPTION
Build is green: https://jenkins.ivyteam.io/job/ivy-project-demos/job/downgrade_to_8.0.1/