### PR TITLE
Feature/try setup travis

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,8 +1,0 @@
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <servers>
-    <server> 
-      <id>nexus.ivyteam.io</id> 
-      <url>https://repo.axonivy.com/artifactory/libs-snapshot-local/</url>
-    </server>
-  </servers>
-</settings>

--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,8 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server> 
+      <id>nexus.ivyteam.io</id> 
+      <url>https://repo.axonivy.com/artifactory/libs-snapshot-local/</url>
+    </server>
+  </servers>
+<settings>

--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -5,4 +5,4 @@
       <url>https://repo.axonivy.com/artifactory/libs-snapshot-local/</url>
     </server>
   </servers>
-<settings>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
   - openjdk11
+install: skip
 script:
   - mvn clean verify -Dmaven.test.skip=true -Divy.engine.download.url=https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ jdk:
   - openjdk11
 install: skip
 script:
+  - cp .travis.settings.xml $HOME/.m2/settings.xml
   - mvn clean verify -Dmaven.test.skip=true -Divy.engine.download.url=https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: java
-services:
-  - docker
-before_install:
-  - docker pull axonivy/build-container:web-1.0
-  - docker run -it -d --name build axonivy/build-container:web-1.0 bash
-  - docker exec build git clone https://github.com/ivy-samples/ivy-project-demos.git
+jdk:
+  - openjdk11
 script:
-  - docker exec build mvn clean verify
+  - mvn clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ jdk:
   - openjdk11
 install: skip
 script:
-  - cp .travis.settings.xml $HOME/.m2/settings.xml
   - mvn clean verify -Dmaven.test.skip=true -Divy.engine.download.url=https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-sudo: required
 language: java
-java:
-  - "11"
 services:
   - docker
 before_install:
-  - docker pull axonivy/axonivy-engine:dev
-  - docker run -it -d --name build axonivy/axonivy-engine bash
+  - docker pull axonivy/build-container:web-1.0
+  - docker run -it -d --name build axonivy/build-container:web-1.0 bash
   - docker exec build git clone https://github.com/ivy-samples/ivy-project-demos.git
 script:
   - docker exec build mvn clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 jdk:
   - openjdk11
 script:
-  - mvn clean verify
+  - mvn clean verify -Dmaven.test.skip=true -Divy.engine.download.url=https://developer.axonivy.com/permalink/nightly/axonivy-engine.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+language: java
+java:
+  - "11"
+services:
+  - docker
+before_install:
+  - docker pull axonivy/axonivy-engine:dev
+  - docker run -it -d --name build axonivy/axonivy-engine bash
+  - docker exec build git clone https://github.com/ivy-samples/ivy-project-demos.git
+script:
+  - docker exec build mvn clean verify

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![demos travis build][0]][1]
+
 # Ivy demo projects
 
 This repository contains multiple demos how to use the Axon.ivy platform.
@@ -29,3 +31,7 @@ If you want to know more about testing checkout our documentation chapter: [Test
 ## increase version
 
 [Increase version job](build.maven/job/update-version/README.md)
+
+
+[0]: https://api.travis-ci.org/ivy-samples/ivy-project-demos.svg?branch=master
+[1]: https://travis-ci.org/github/ivy-samples/ivy-project-demos

--- a/demos-app/pom.xml
+++ b/demos-app/pom.xml
@@ -59,6 +59,16 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>nexus.ivyteam.io</id>
+      <url>https://nexus.ivyteam.io/repository/maven/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
   <build>

--- a/demos-app/pom.xml
+++ b/demos-app/pom.xml
@@ -3,14 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ch.ivyteam.demo</groupId>
   <artifactId>ivy-demos-app</artifactId>
+  <version>9.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-
-  <parent>
-    <!-- here to inherit dependencyManagement in order to verify its actuality -->
-    <groupId>ch.ivyteam.ivy</groupId>
-    <artifactId>maven-config-dependencies</artifactId>
-    <version>9.1.0-SNAPSHOT</version>
-  </parent>
 
   <dependencies>
     <dependency>

--- a/demos-app/pom.xml
+++ b/demos-app/pom.xml
@@ -3,14 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ch.ivyteam.demo</groupId>
   <artifactId>ivy-demos-app</artifactId>
+  <version>9.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <parent>
-    <!-- here to inherit dependencyManagement in order to verify its actuality -->
-    <groupId>ch.ivyteam.ivy</groupId>
-    <version>9.1.0-SNAPSHOT</version>
-    <artifactId>maven-config-dependencies</artifactId>
-  </parent>
+  <properties>
+    <ivyteam.rule.engine.demo.project.version>9.1.0-SNAPSHOT</ivyteam.rule.engine.demo.project.version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -57,16 +55,6 @@
       <url>https://repo.axonivy.com/artifactory/libs-snapshot-local</url>
       <snapshots>
         <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>nexus.ivyteam.io</id>
-      <url>https://nexus.ivyteam.io/repository/maven/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
       </snapshots>
     </repository>
   </repositories>

--- a/demos-app/pom.xml
+++ b/demos-app/pom.xml
@@ -3,8 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ch.ivyteam.demo</groupId>
   <artifactId>ivy-demos-app</artifactId>
-  <version>9.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
+  <parent>
+    <!-- here to inherit dependencyManagement in order to verify its actuality -->
+    <groupId>ch.ivyteam.ivy</groupId>
+    <version>9.1.0-SNAPSHOT</version>
+    <artifactId>maven-config-dependencies</artifactId>
+  </parent>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0-M1</version>
         <configuration>
           <skip>true</skip>
         </configuration>


### PR DESCRIPTION
Needed to remove the core dependecy pom as parent from the demos app, because this has the nexus.ivyteam.io as repository. This is not a functional blocker but travis trys to connect to it and has multiple times connection timeouts. 
Means the build needs a unacceptable amount of time to finish.
The problem is now that someone maybe forgets to set the new version for the rule demos...

Travis runs without tests because all webtests will not work without the firefox dependecy... but maybe we can run the process tests (or even the webtests by install firefox...)