### PR TITLE
XIVY-3574 fix old maven repo

### DIFF
--- a/build.maven/job/update-version/pom.xml
+++ b/build.maven/job/update-version/pom.xml
@@ -11,15 +11,13 @@
   <properties>
     <ivy.root.relative>/../../..</ivy.root.relative>
     <ivy.root.dir>${basedir}${ivy.root.relative}</ivy.root.dir>
-    <nexus.root.url>http://zugpronexus:8081/nexus</nexus.root.url>
   </properties>
 
   <pluginRepositories>
     <!-- Used to install ivy maven plugins -->
     <pluginRepository>
-      <id>zugpronexus.build-plugins</id>
-      <name>Internal Plugin Build Integration Repository</name>
-      <url>${nexus.root.url}/content/groups/build-plugins/</url>
+      <id>nexus.ivyteam.io</id>
+      <url>https://nexus.ivyteam.io/repository/maven/</url>
       <snapshots>
         <updatePolicy>always</updatePolicy>
       </snapshots>
@@ -62,7 +60,7 @@
       <plugin>
         <groupId>ch.ivyteam</groupId>
         <artifactId>maven-version-plugin</artifactId>
-        <version>2.0.2-SNAPSHOT</version>
+        <version>2.0.4-SNAPSHOT</version>
         <configuration>
           <version>${new.ivy.version}-SNAPSHOT</version>
         </configuration>

--- a/build.maven/job/update-version/pom.xml
+++ b/build.maven/job/update-version/pom.xml
@@ -58,9 +58,9 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>ch.ivyteam</groupId>
+        <groupId>ch.ivyteam.maven</groupId>
         <artifactId>maven-version-plugin</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>9.1.4-SNAPSHOT</version>
         <configuration>
           <version>${new.ivy.version}-SNAPSHOT</version>
         </configuration>


### PR DESCRIPTION
found another zugpronexus repo...
But honestly does anyone use this update-version maven execution? This will never run on any pc except we deploy the maven-version-plugin on repo.axonivy.com... And in my opinion this should never run on any pc (or even be on this github repo). I use always VSCode Search/Replace for a version update...
I vote for complete removal of this update-version part!

But anyway here s the fix to use the new nexus.ivyteam.io repo.