### PR TITLE
XIVY-3867 fix: chat resource URI in JS

### DIFF
--- a/connectivity/connectivity-demos/webContent/js/ivy.js
+++ b/connectivity/connectivity-demos/webContent/js/ivy.js
@@ -5,8 +5,7 @@ function IvyUri()
     var baseUri = window.location.origin; // e.g. http://localhost:8080
     var path = window.location.pathname.split( '/' ); // assume faces uri
     var webAppCtxt = path[1]; // e.g. /ivy
-    var app = path[4]; // e.g. /designer
-    var restUri = baseUri+"/"+webAppCtxt+"/api/"+app;
+    var restUri = baseUri+"/"+webAppCtxt+"/api";
     return restUri
   }
 }


### PR DESCRIPTION
- was no longer compatible to current master (9.1)

![brokenChatDemo](https://user-images.githubusercontent.com/15085693/82340234-490c5580-99ef-11ea-9241-302ee9e1ce6a.png)
![fixedChatDemo](https://user-images.githubusercontent.com/15085693/82340239-4ad61900-99ef-11ea-9604-06bfd9a1f462.png)
