### PR TITLE
Bugfix/xivy 4022 async client fetch aborter

### DIFF
--- a/connectivity/connectivity-demos/src_hd/com/axonivy/connectivity/rest/ChatClient/ChatClient.xhtml
+++ b/connectivity/connectivity-demos/src_hd/com/axonivy/connectivity/rest/ChatClient/ChatClient.xhtml
@@ -25,12 +25,9 @@
           chat.users(view.renderUsers);
           chat.listen(view.renderMessages);
 
-          async
-          function send() {
-            var text = document
-              .getElementById('form:sendMsg');
-            var users = document
-              .getElementById('users');
+          async function send() {
+            var text = document.getElementById('form:sendMsg');
+            var users = document.getElementById('users');
             var receiver = users.options[users.selectedIndex].value;
 
             if (receiver == "@ALL") {

--- a/connectivity/connectivity-demos/src_hd/com/axonivy/connectivity/rest/ChatClient/ChatClient.xhtml
+++ b/connectivity/connectivity-demos/src_hd/com/axonivy/connectivity/rest/ChatClient/ChatClient.xhtml
@@ -61,7 +61,7 @@
           <h:inputText id="sendMsg"></h:inputText>
         </div>
         <br />
-        <p:commandButton actionListener="#{logic.close}" style="margin-top:100px;" value="Leave" update="form"
+        <p:commandButton onclick="chat.aborter.abort()" actionListener="#{logic.close}" style="margin-top:100px;" value="Leave" update="form"
           icon="fa fa-close" />
       </h:form>
 

--- a/connectivity/connectivity-demos/src_hd/com/axonivy/connectivity/rest/ChatClient/resources/chat.js
+++ b/connectivity/connectivity-demos/src_hd/com/axonivy/connectivity/rest/ChatClient/resources/chat.js
@@ -1,6 +1,7 @@
 function Chat(uri) {
   // current service uri: e.g. "http://localhost:8081/designer/api/chatdemo"
   this.uri = uri;
+  this.aborter = new AbortController();
 
   this.users = async function (callback) {
     const response = await fetch(uri + "/users");
@@ -10,7 +11,10 @@ function Chat(uri) {
   }
 
   this.listen = async function (callback) {
-    const response = await fetch(uri);
+	let abortSignal =  this.aborter.signal;
+    const response = await fetch(uri, {
+      signal: abortSignal
+    });
     const messages = await response.json();
     this.listen(callback); // wait for next update
     callback(messages); // update UI


### PR DESCRIPTION
Extend the chat demo: mainly to demonstrate JS client enforced cancellation of pending async REST requests 

Solved with Aborter: https://javascript.info/fetch-abort

![abortChatViaBrowserTools](https://user-images.githubusercontent.com/15085693/83147467-00901e80-a0f8-11ea-9ef0-fff2b44d7ac5.png)
![abortedFetch-chrome](https://user-images.githubusercontent.com/15085693/83147469-0128b500-a0f8-11ea-8f2b-7faa8c72f4fc.png)
