### PR TITLE
XIVY-494 fix: reflection warnings in build pipeline

### DIFF
--- a/build.maven/web/pom.xml
+++ b/build.maven/web/pom.xml
@@ -67,6 +67,12 @@
           <additionalVmOptions>-Divy.Errors.ShowDetailsToEndUser=true</additionalVmOptions>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <!-- downgrade to M4: avoid reflection warnings until 9.1.1 project-build-plugin is public available. -->
+        <version>3.0.0-M4</version>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
- downgrade to M4 surefire plugin which does not log these kind of warnings
- as soon as 9.1 is released we can switch to the 9.1.1 project-build-plugin snap that addresses this issue correctly.