### PR TITLE
Provide a common raise-version.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,3 @@ mvn clean verify
 ```
 
 If you want to know more about testing checkout our documentation chapter: [Testing](https://developer.axonivy.com/doc/dev/concepts/testing.html)
-
-## Raise version
-
-1. Execute `mvn -f build.maven/raise-version/pom.xml versions:set versions:commit -DnewVersion=9.2.0-SNAPSHOT -DprocessAllModules`
-2. Raise version in core repository

--- a/raise-version.sh
+++ b/raise-version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mvn -f build.maven/raise-version/pom.xml versions:set versions:commit -DnewVersion=${1} -DprocessAllModules


### PR DESCRIPTION
I will provide in all repos a `raise-version.sh` script. There you can pass as first argument the new version number. We don't explain our common approach in all README.md in all repos anymore.