### PR TITLE
XIVY-4019 cluster services under a 'demo' tag

### DIFF
--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/aynch/chat/ChatService.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/aynch/chat/ChatService.java
@@ -23,7 +23,10 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 
+import com.axonivy.connectivity.rest.provider.ApiConstants;
+
 import ch.ivyteam.ivy.environment.Ivy;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  * Demonstrates asynchronous REST communication:
@@ -38,8 +41,9 @@ import ch.ivyteam.ivy.environment.Ivy;
  * @author rew
  * @since 7.3.0
  */
-@Path("chatdemo")
 @Singleton
+@Path("chatdemo")
+@Tag(name = ApiConstants.DEMO_TAG)
 public class ChatService
 {
 

--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/ApiConstants.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/ApiConstants.java
@@ -1,0 +1,6 @@
+package com.axonivy.connectivity.rest.provider;
+
+public interface ApiConstants
+{
+  String DEMO_TAG = "demo";
+}

--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/ApprovalService.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/ApprovalService.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.UriBuilder;
 
 import ch.ivyteam.ivy.process.call.SubProcessCall;
 import ch.ivyteam.ivy.workflow.ITask;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  * RESTful Service that demonstrates how to interact with the ivy environment
@@ -24,6 +25,7 @@ import ch.ivyteam.ivy.workflow.ITask;
  * </p>
  */
 @Path("approve")
+@Tag(name = ApiConstants.DEMO_TAG)
 public class ApprovalService
 {
 

--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/BatchService.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/BatchService.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.Response;
 import org.glassfish.jersey.server.ManagedAsync;
 
 import ch.ivyteam.ivy.environment.Ivy;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  * Simulates a slow remote service that takes seconds to deliver a result.
@@ -23,6 +24,7 @@ import ch.ivyteam.ivy.environment.Ivy;
  * </p>
  */
 @Path("batch")
+@Tag(name = ApiConstants.DEMO_TAG)
 public class BatchService
 {
 

--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/FileService.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/FileService.java
@@ -33,12 +33,14 @@ import ch.ivyteam.api.API;
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.scripting.objects.File;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  * URI for file upload: http://localhost:8081/designer/api/file
  * @since 7.3.0
  */
 @Path("file")
+@Tag(name = ApiConstants.DEMO_TAG)
 public class FileService
 {
   @GET

--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/PersonService.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/PersonService.java
@@ -29,6 +29,7 @@ import com.axonivy.connectivity.Person;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  * Simple RESTful service. The REST interface is defined by the JAX-RS
@@ -52,6 +53,7 @@ import io.swagger.v3.oas.annotations.Parameter;
  */
 @Singleton
 @Path("persons")
+@Tag(name = ApiConstants.DEMO_TAG)
 public class PersonService
 {
 

--- a/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/SecureService.java
+++ b/connectivity/connectivity-demos/src/com/axonivy/connectivity/rest/provider/SecureService.java
@@ -20,6 +20,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * Demonstrates a service which protects it's methods with
  * <code>javax.security</code> annotations.
@@ -46,6 +48,7 @@ import javax.ws.rs.core.Response.Status;
  */
 @Singleton
 @Path("admin")
+@Tag(name = ApiConstants.DEMO_TAG)
 public class SecureService
 {
 


### PR DESCRIPTION
... helps to separate them from other services once the
connectivity-demos is published among other endpoints to a wf-app.