### PR TITLE
fix test: json returned by public PetStore is corrupt

### DIFF
--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -111,6 +111,15 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <systemPropertyVariables>
+              <test.environment>dev-axonivy</test.environment>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>com.axonivy.ivy.ci</groupId>
           <artifactId>project-build-plugin</artifactId>
           <executions>


### PR DESCRIPTION
- currently swaggers service reurns an invalid pet list : so don't get
distracted by jackson deserializer warnings
- however; we should run against our own infrastructure anway.